### PR TITLE
MARKITUP_AUTO_PREVIEW fix

### DIFF
--- a/markitup/widgets.py
+++ b/markitup/widgets.py
@@ -75,7 +75,7 @@ class MarkItUpWidget(MarkupTextarea):
         final_attrs = self.build_attrs(attrs)
 
         if self.auto_preview:
-            auto_preview = "$('a[title=\"Preview\"]').trigger('mouseup');"
+            auto_preview = "$('a[title=\"Preview\"]').trigger('mousedown');"
         else: auto_preview = ''
 
         try:


### PR DESCRIPTION
markItUp changed observed event on toolbar items to mousedown. this
commit just fixes MARKITUP_AUTO_PREVIEW to working state.
