### PR TITLE
Fix trove classifiers.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Framework :: Django',


### PR DESCRIPTION
Quoted from:

```
In order to show up on the list of projects that support Python 3,
the project needs to set the Programming Language :: Python :: 3
trove classifier.
```

http://nothingbutsnark.svbtle.com/my-experience-creating-caniusepython3
