### PR TITLE
allows https or http version of jquery to load preventing it from being blocked on https admin pages

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -373,7 +373,7 @@ JQUERY_URL
 
 MarkItUp! requires the jQuery Javascript library.  By default, django-markitup
 links to jQuery 2.0.3 at ajax.googleapis.com (via the URL
-``http://ajax.googleapis.com/ajax/libs/jquery/2.0.3/jquery.min.js``).  If you
+``//ajax.googleapis.com/ajax/libs/jquery/2.0.3/jquery.min.js``).  If you
 wish to use a different version of jQuery, or host it yourself, set the
 JQUERY_URL setting.  For example::
 

--- a/markitup/settings.py
+++ b/markitup/settings.py
@@ -9,4 +9,4 @@ MARKITUP_SET = getattr(settings, 'MARKITUP_SET', 'markitup/sets/default')
 MARKITUP_SKIN = getattr(settings, 'MARKITUP_SKIN', 'markitup/skins/simple')
 JQUERY_URL = getattr(
     settings, 'JQUERY_URL',
-    'http://ajax.googleapis.com/ajax/libs/jquery/2.0.3/jquery.min.js')
+    '//ajax.googleapis.com/ajax/libs/jquery/2.0.3/jquery.min.js')


### PR DESCRIPTION
By default the non-https version of jquery is downloaded. As `django-markitup` is pulled in from a bunch of other Django apps, it's not always known what is broken in the admin page when a non-https is block by the brower.

Fixes this: 
![image](https://cloud.githubusercontent.com/assets/2336595/11412627/f9d18b22-9393-11e5-9958-d26d6c5acd10.png)
