### PR TITLE
New defaults that are friendly to CachedFilesStorage

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -266,13 +266,13 @@ To use an alternate set, assign the ``MARKITUP_SET`` setting a URL path
 (absolute or relative to ``STATIC_URL``) to the set directory.  For
 instance, to use the "markdown" set included with django-markitup::
 
-    MARKITUP_SET = 'markitup/sets/markdown'
+    MARKITUP_SET = 'markitup/sets/markdown/'
 
 MarkItUp! skins can be specified in a similar manner.  Both "simple"
 and "markitup" skins are included, by default "simple" is used.  To
 use the "markitup" skin instead::
 
-    MARKITUP_SKIN = 'markitup/skins/markitup'
+    MARKITUP_SKIN = 'markitup/skins/markitup/'
 
 Neither of these settings has to refer to a location inside
 django-markitup's media.  You can define your own sets and skins and

--- a/markitup/settings.py
+++ b/markitup/settings.py
@@ -5,8 +5,9 @@ from django.conf import settings
 MARKITUP_PREVIEW_FILTER = getattr(settings, 'MARKITUP_PREVIEW_FILTER',
                                   getattr(settings, 'MARKITUP_FILTER', None))
 MARKITUP_AUTO_PREVIEW = getattr(settings, 'MARKITUP_AUTO_PREVIEW', False)
-MARKITUP_SET = getattr(settings, 'MARKITUP_SET', 'markitup/sets/default')
-MARKITUP_SKIN = getattr(settings, 'MARKITUP_SKIN', 'markitup/skins/simple')
+# Defaults include trailing slash so that others know path is a directory
+MARKITUP_SET = getattr(settings, 'MARKITUP_SET', 'markitup/sets/default/')
+MARKITUP_SKIN = getattr(settings, 'MARKITUP_SKIN', 'markitup/skins/simple/')
 JQUERY_URL = getattr(
     settings, 'JQUERY_URL',
     'http://ajax.googleapis.com/ajax/libs/jquery/2.0.3/jquery.min.js')

--- a/tests/project/settings.py
+++ b/tests/project/settings.py
@@ -12,7 +12,7 @@ TEMPLATE_DIRS = [join(BASE_DIR, 'templates')]
 ROOT_URLCONF = 'tests.project.urls'
 
 MARKITUP_FILTER = ('markdown.markdown', {'safe_mode': True})
-MARKITUP_SET = 'markitup/sets/markdown'
+MARKITUP_SET = 'markitup/sets/markdown/'  # Default includes trailing slash so that others know it's a directory
 
 DEBUG = True
 


### PR DESCRIPTION
Updates the default paths for MARKITUP_SET and MARKITUP_SKIN to make it more obvious to other apps that these are directories and not files.

Doing this will prevent a gotcha for those [using CachedFileStorage](https://github.com/WimpyAnalytics/django-andablog/issues/47). As not including the / with cached file storage will actually break the user's entire site as absolute_url is called during import and ends up being evaluated as a file rather then a directory. 

This change will not affect those who are not using cached file storage. 