### PR TITLE
Initial Django 1.11 and 2.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,23 @@ addons:
         packages:
             - python3.5
             - python3.5-dev
+            - python3.6
+            - python3.6-dev
 env:
     - TOXENV=py27-1.8
     - TOXENV=py27-1.9
     - TOXENV=py27-1.10
+    - TOXENV=py27-1.11
     - TOXENV=py34-1.8
     - TOXENV=py34-1.9
     - TOXENV=py34-1.10
+    - TOXENV=py34-1.11
     - TOXENV=py35-1.9
     - TOXENV=py35-1.10
+    - TOXENV=py35-1.11
+    - TOXENV=py35-2.0
+    - TOXENV=py36-1.11
+    - TOXENV=py36-2.0
 install:
     - pip install tox
 script:

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -12,4 +12,5 @@ Mikhael Korneev
 Neil Muller
 Roman Akinfold <akinfold@gmail.com>
 Sebastian Brandt
+Stefano Rivera <stefano@rivera.za.net>
 Zbigniew Siciarz <zbigniew@siciarz.net>

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ CHANGES
 master (unreleased)
 -------------------
 
-* none yet
+* Add support for Django 1.11 and 2.0.
 
 3.0.0 (2016.09.04)
 ------------------

--- a/markitup/fields.py
+++ b/markitup/fields.py
@@ -99,7 +99,7 @@ class MarkupField(models.TextField):
         return value.raw
 
     def value_to_string(self, obj):
-        value = self._get_val_from_obj(obj)
+        value = self.value_from_object(obj)
         return value.raw
 
     def to_python(self, value):

--- a/markitup/templatetags/markitup_tags.py
+++ b/markitup/templatetags/markitup_tags.py
@@ -1,10 +1,15 @@
 from __future__ import unicode_literals
 
 from django import template
-from django.core.urlresolvers import reverse, NoReverseMatch
 from markitup import settings
 from markitup.util import absolute_url
 from markitup.fields import render_func
+
+try:
+    from django.urls import NoReverseMatch, reverse
+except ImportError:
+    # pre-Django 1.10
+    from django.core.urlresolvers import NoReverseMatch, reverse
 
 register = template.Library()
 

--- a/markitup/widgets.py
+++ b/markitup/widgets.py
@@ -3,11 +3,16 @@ from __future__ import unicode_literals
 import posixpath
 from django import forms
 from django.contrib.admin.widgets import AdminTextareaWidget
-from django.core.urlresolvers import NoReverseMatch, reverse
 from django.template.loader import render_to_string
 from django.utils.safestring import mark_safe
 from markitup import settings
 from markitup.util import absolute_url
+
+try:
+    from django.urls import NoReverseMatch, reverse
+except ImportError:
+    # pre-Django 1.10
+    from django.core.urlresolvers import NoReverseMatch, reverse
 
 
 class MarkupInput(forms.Widget):

--- a/markitup/widgets.py
+++ b/markitup/widgets.py
@@ -76,7 +76,10 @@ class MarkItUpWidget(MarkupTextarea):
     def render(self, name, value, attrs=None):
         html = super(MarkItUpWidget, self).render(name, value, attrs)
 
-        final_attrs = self.build_attrs(attrs)
+        # Passing base_attrs as a kwarg for compatibility with Django < 1.11
+        # (where it will be treated as an innocuous attr named base_attrs)
+        final_attrs = self.build_attrs(
+            base_attrs=self.attrs, extra_attrs=attrs)
 
         try:
             preview_url = reverse('markitup_preview')

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,22 @@
 [tox]
 envlist=
-  py27-1.{8,9,10},
-  py34-1.{8,9,10},
-  py35-1.{9,10}
+  py27-1.{8,9,10,11},
+  py34-1.{8,9,10,11},
+  py34-2.0,
+  py35-1.{9,10,11},
+  py35-2.0,
+  py36-{1.11,2.0}
 
 [testenv]
 basepython =
   py27: python2.7
   py34: python3.4
   py35: python3.5
+  py36: python3.6
 commands=python setup.py test
 deps =
   1.8: Django>=1.8,<1.9
   1.9: Django>=1.9,<1.10
   1.10: Django>=1.10,<1.11
+  1.11: Django>=1.11,<2.0
+  2.0: Django>=2.0,<2.1


### PR DESCRIPTION
Enough to pass tests. (tested on everything except Python 3.4).

There are some compatibility hacks (noted with comments) that can be rolled back, once older Django support is dropped.

Fixes: #22